### PR TITLE
2 2 contact form types

### DIFF
--- a/ProjectLily/src/templates/contact.html
+++ b/ProjectLily/src/templates/contact.html
@@ -12,6 +12,47 @@
 
           {{ form.hidden_tag() }}
 
+          {% if not current_user.is_authenticated %}
+            <div>
+                {% if form.name.errors %}
+                    {{ form.name(class="form-control form-control-lg is-invalid mt-5") }}
+                    <div class="invalid-feedback">
+                        {% for error in form.name.errors %}
+                            <span>{{ error }}</span>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    {{ form.name(class="userinput mt-3", placeholder=form.name.label.text) }}
+                {% endif %}
+            </div>
+
+            <div>
+                {% if form.email.errors %}
+                    {{ form.email(class="form-control form-control-lg is-invalid mt-5") }}
+                    <div class="invalid-feedback">
+                        {% for error in form.email.errors %}
+                            <span>{{ error }}</span>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    {{ form.email(class="userinput mt-3", placeholder=form.email.label.text) }}
+                {% endif %}
+            </div>
+
+            <div>
+                {% if form.phone.errors %}
+                    {{ form.phone(class="form-control form-control-lg is-invalid mt-5") }}
+                    <div class="invalid-feedback">
+                        {% for error in form.phone.errors %}
+                            <span>{{ error }}</span>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    {{ form.phone(class="userinput mt-3", placeholder=form.phone.label.text) }}
+                {% endif %}
+            </div>
+          {% endif %}
+
           <div>
               {% if form.subject.errors %}
                   {{ form.subject(class="form-control form-control-lg is-invalid mt-5") }}

--- a/ProjectLily/src/users/forms.py
+++ b/ProjectLily/src/users/forms.py
@@ -70,6 +70,16 @@ class ContactForm(FlaskForm):
     email_content = TextAreaField('Content of Email', validators=[DataRequired()])
     submit = SubmitField('Send')
 
+class ContactFormLoggedOut(FlaskForm):
+    """
+        Contact form when logged out (not signed in)
+    """
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    phone = IntegerField('Phone Number', validators=[DataRequired()])
+    subject = StringField('Subject', validators=[DataRequired(), Length(max=100)])
+    email_content = TextAreaField('Content of Email', validators=[DataRequired()])
+    submit = SubmitField('Send')
+
 class RequestPasswordResetForm(FlaskForm):
     """
         Request a password reset link form

--- a/ProjectLily/src/users/forms.py
+++ b/ProjectLily/src/users/forms.py
@@ -74,6 +74,7 @@ class ContactFormLoggedOut(FlaskForm):
     """
         Contact form when logged out (not signed in)
     """
+    name = StringField('Name', validators=[DataRequired(), Length(max=33)])
     email = StringField('Email', validators=[DataRequired(), Email()])
     phone = IntegerField('Phone Number', validators=[DataRequired()])
     subject = StringField('Subject', validators=[DataRequired(), Length(max=100)])

--- a/ProjectLily/src/users/routes.py
+++ b/ProjectLily/src/users/routes.py
@@ -22,7 +22,7 @@ def contact():
             return redirect(url_for('main.index'))
     else:
         if form.validate_on_submit():
-            send_contact_email_logged_out(form.email.data, form.phone.data, form.subject.data, form.email_content.data)
+            send_contact_email_logged_out(form.name.data, form.email.data, form.phone.data, form.subject.data, form.email_content.data)
             flash('Email sent! Thanks for getting in touch!', 'success')
             return redirect(url_for('main.index'))
     return render_template('contact.html', title="Contact", form=form)

--- a/ProjectLily/src/users/util.py
+++ b/ProjectLily/src/users/util.py
@@ -67,12 +67,12 @@ If you did not attempt to sign up to Lily Foster Art, then you may ignore this e
 '''
     mail.send(email_msg)
 
-def send_contact_email_logged_out(email, phone, subject, content):
+def send_contact_email_logged_out(name, email, phone, subject, content):
     email_msg = Message(subject, sender='lilyfosterart.business@gmail.com', recipients=[app_email])
     email_msg.body = f'''{content}
 
 User Details:
-Name: Unkown
+Name: {name}
 Email: {email}
 Phone: {phone}
 '''

--- a/ProjectLily/src/users/util.py
+++ b/ProjectLily/src/users/util.py
@@ -66,3 +66,14 @@ def send_email_confirmation(user_info):
 If you did not attempt to sign up to Lily Foster Art, then you may ignore this email.    
 '''
     mail.send(email_msg)
+
+def send_contact_email_logged_out(email, phone, subject, content):
+    email_msg = Message(subject, sender='lilyfosterart.business@gmail.com', recipients=[app_email])
+    email_msg.body = f'''{content}
+
+User Details:
+Name: Unkown
+Email: {email}
+Phone: {phone}
+'''
+    mail.send(email_msg)


### PR DESCRIPTION
There now exists 2 contact forms, one to be shown to users who are not logged in, where they must provide contact details to be appended to the contact email. The first remains unchanged and only requires the subject and content of the email as the user is signed in to see this contact form and their contact details, which are also appended to the email can be automatically retrieved from their account information, as they are signed in.

Closes #2 