### PR TITLE
Sidebar updated for mobile.

### DIFF
--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -4,6 +4,7 @@
 :root{
   --clr-neutral-900: #000;
   --clr-neutral-400: #444;
+  --clr-neutral-300: #888;
   --clr-neutral-100: #FFF;
 
   --ff-base: 'Poiret One', cursive;
@@ -41,7 +42,6 @@ a, a:hover{
   font-size: clamp(1rem, 4vw + 0.65rem, 4rem);
   color: var(--clr-neutral-900);
   font-weight: var(--fw-boldest);
-  background-color: var(--clr-neutral-100);
   margin-left: 5%;
   margin-right: 5%;
   border-bottom: solid;
@@ -75,11 +75,9 @@ a, a:hover{
 .sidebar-slide-out{
   background-color: var(--clr-neutral-100);
   font-family: var(--ff-accent);
-  font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+  font-size: clamp(1.5rem, 4vw + 0.5rem, 2rem);
   font-weight: var(--fw-boldest);
   text-align: left;
-  padding-left: 15%;
-  padding-top: 5%;
   overflow-y: scroll;
   overflow-x: hidden;
 
@@ -87,12 +85,11 @@ a, a:hover{
   top: 0;
   bottom: 0;
   left: 0;
-  right: 40%;
+  right: 55%;
   z-index: 10;
 
   border: 3px solid;
-
-  align-content: center;
+  border-radius: 0 15px 15px 0;
 
   transform: translateX(-100%);
   transition: transform ease-out 200ms;
@@ -103,7 +100,15 @@ a, a:hover{
 }
 
 .sidebar-open{
+  background-color: var(--clr-neutral-300);
+  z-index: 5;
   overflow-y: hidden;
+}
+
+.sidebar-out-content{
+  width: 100%;
+  display: grid;
+  justify-items: center;
 }
 
 .imgStyle{
@@ -309,17 +314,7 @@ a, a:hover{
   border: 0;
 }
 
-.btn-style-close {
-  margin-left: 5%;
-  background: transparent;
-  border: 0;
-}
-
 .btn-style:focus {
-  outline: none;
-}
-
-.btn-style-close:focus {
   outline: none;
 }
 

--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -105,6 +105,10 @@ a, a:hover{
   overflow-y: hidden;
 }
 
+.sidebar-open .containerMainBody{
+  content-visibility: hidden;
+}
+
 .sidebar-out-content{
   width: 100%;
   display: grid;
@@ -261,10 +265,6 @@ a, a:hover{
   width: clamp(80px, 20vw + 50px, 307px);
   height: clamp(107px, 30vw + 80px, 409.6px);
   transition: transform .3s;
-}
-
-.content-section {
-  background: var(--clr-neutral-100);
 }
 
 .account-heading {

--- a/ProjectLily/src/templates/layout.html
+++ b/ProjectLily/src/templates/layout.html
@@ -35,8 +35,8 @@
         </div>
 
         <div class="menu-container">
-            <button class="btn-style">
-                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+            <button class="btn-style" onclick="openSidebar()">
+                <svg class="openBtn" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
                 </svg>
             </button>
@@ -59,54 +59,54 @@
 
         <div class="sidebar-slide-out">
             <div class="menu-container" style="float: right;">
-                <button class="btn-style-close">
+                <button class="btn-style" onclick="closeSidebar()">
                     <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
                         <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
                       </svg>
                 </button>
             </div>
-            <h1 class="account-heading-special">Sidebar:</h1>
-            <a class="hover-underline-animation" href="{{ url_for('main.index') }}">Home</a><br>
-            
-            <a class="hover-underline-animation mt-2" href="{{ url_for('art.gallery') }}">Gallery</a><br>
-
-            <!--<a class="hover-underline-animation mt-2" href="{{ url_for('art.shop') }}">Shop</a><br>-->
-            
-            <!--<a class="hover-underline-animation mt-2" href="{{ url_for('art.cart') }}">Cart</a><br>-->
-
-            <a class="hover-underline-animation mt-2" href="{{ url_for('users.contact') }}">Contact</a><br>
-            
-            <a class="hover-underline-animation mt-2" href="{{ url_for('main.about') }}">About</a><br>
-        
-            {% if current_user.is_authenticated %}
-                <br>
-                <br>
-                <br>
-                <a class="hover-underline-animation" href="{{ url_for('users.account') }}">Account</a><br>
-                <a class="hover-underline-animation mt-2" href="#" data-toggle="modal" data-target="#signoutModal">Sign out</a><br>
-            {% else %}
-                <br>
-                <br>
-                <br>
-                <a class="hover-underline-animation" href="{{ url_for('users.signin') }}">Sign in</a><br>
-                <a class="hover-underline-animation mt-2" href="{{ url_for('users.signup') }}">Sign up</a><br>
-            {% endif %}
-            
-            <a class="hover-rotate mt-2" href="https://twitter.com/M__Foster" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
-                    <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
-                </svg>
-            </a>
-            <a class="hover-rotate mt-2" href="https://www.instagram.com/_lilyjfoster_/" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
-                    <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.917 3.917 0 0 0-1.417.923A3.927 3.927 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.916 3.916 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.926 3.926 0 0 0-.923-1.417A3.911 3.911 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0h.003zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599.28.28.453.546.598.92.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.47 2.47 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.478 2.478 0 0 1-.92-.598 2.48 2.48 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233 0-2.136.008-2.388.046-3.231.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92.28-.28.546-.453.92-.598.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045v.002zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92zm-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217zm0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334z"/>
-                </svg>
-            </a>
-            <a class="hover-rotate mt-4" href="https://twitter.com/M__Foster" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
-                    <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"/>
-                </svg>
-            </a>
+            <div class="sidebar-out-content">
+                <div>
+                    <a class="hover-underline-animation" href="{{ url_for('main.index') }}">Home</a><br>
+                    
+                    <a class="hover-underline-animation mt-2" href="{{ url_for('art.gallery') }}">Gallery</a><br>
+                    <!--<a class="hover-underline-animation mt-2" href="{{ url_for('art.shop') }}">Shop</a><br>-->
+                    
+                    <!--<a class="hover-underline-animation mt-2" href="{{ url_for('art.cart') }}">Cart</a><br>-->
+                    <a class="hover-underline-animation mt-2" href="{{ url_for('users.contact') }}">Contact</a><br>
+                    
+                    <a class="hover-underline-animation mt-2" href="{{ url_for('main.about') }}">About</a><br>
+                    {% if current_user.is_authenticated %}
+                        <br>
+                        <br>
+                        <br>
+                        <a class="hover-underline-animation" href="{{ url_for('users.account') }}">Account</a><br>
+                        <a class="hover-underline-animation mt-2" href="#" data-toggle="modal" data-target="#signoutModal">Sign out</a><br>
+                    {% else %}
+                        <br>
+                        <br>
+                        <br>
+                        <a class="hover-underline-animation" href="{{ url_for('users.signin') }}">Sign in</a><br>
+                        <a class="hover-underline-animation mt-2" href="{{ url_for('users.signup') }}">Sign up</a><br>
+                    {% endif %}
+                    
+                    <a class="hover-rotate mt-2" href="https://twitter.com/M__Foster" target="_blank">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
+                            <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
+                        </svg>
+                    </a>
+                    <a class="hover-rotate mt-2" href="https://www.instagram.com/_lilyjfoster_/" target="_blank">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
+                            <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.917 3.917 0 0 0-1.417.923A3.927 3.927 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.916 3.916 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.926 3.926 0 0 0-.923-1.417A3.911 3.911 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0h.003zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599.28.28.453.546.598.92.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.47 2.47 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.478 2.478 0 0 1-.92-.598 2.48 2.48 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233 0-2.136.008-2.388.046-3.231.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92.28-.28.546-.453.92-.598.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045v.002zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92zm-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217zm0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334z"/>
+                        </svg>
+                    </a>
+                    <a class="hover-rotate mt-4" href="https://twitter.com/M__Foster" target="_blank">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
+                            <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
         </div>
 
         <div class="containerMainBody">

--- a/ProjectLily/src/templates/layout.html
+++ b/ProjectLily/src/templates/layout.html
@@ -139,42 +139,42 @@
                     {% endif %}
                     
                     <a class="hover-rotate mt-2" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
                             <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-2" href="https://www.instagram.com/_lilyjfoster_/" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
                             <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.917 3.917 0 0 0-1.417.923A3.927 3.927 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.916 3.916 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.926 3.926 0 0 0-.923-1.417A3.911 3.911 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0h.003zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599.28.28.453.546.598.92.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.47 2.47 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.478 2.478 0 0 1-.92-.598 2.48 2.48 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233 0-2.136.008-2.388.046-3.231.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92.28-.28.546-.453.92-.598.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045v.002zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92zm-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217zm0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-4" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem, 2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
                             <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"/>
                         </svg>
                     </a>
                 </div>
             </div>
-            <!-- Modal -->
-            <div class="modal fade" id="signoutModal" tabindex="-1" role="dialog" aria-labelledby="signoutModalLabel" aria-hidden="true">
-                <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                    <h5 class="modal-title" id="signoutModalLabel" style="font-weight: bolder;">Sign Out?</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                    </div>
-                    <div class="modal-footer">
-                    <button type="button" class="btn btn-light mt-2" data-dismiss="modal">Close</button>
-                    <form action="{{ url_for('users.signout') }}">
-                        <input class="btn btn-dark mt-2" type="submit" value="Sign Out">
-                    </form>
-                    </div>
+            {% block content %}{% endblock %}
+        </div>
+        <!-- Modal -->
+        <div class="modal fade" id="signoutModal" tabindex="-1" role="dialog" aria-labelledby="signoutModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                <h5 class="modal-title" id="signoutModalLabel" style="font-weight: bolder;">Sign Out?</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
                 </div>
+                <div class="modal-footer">
+                <button type="button" class="btn btn-light mt-2" data-dismiss="modal">Close</button>
+                <form action="{{ url_for('users.signout') }}">
+                    <input class="btn btn-dark mt-2" type="submit" value="Sign Out">
+                </form>
                 </div>
             </div>
-            {% block content %}{% endblock %}
+            </div>
         </div>
         <!-- Optional JavaScript -->
         <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/ProjectLily/src/templates/layout.html
+++ b/ProjectLily/src/templates/layout.html
@@ -91,17 +91,17 @@
                     {% endif %}
                     
                     <a class="hover-rotate mt-2" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
                             <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-2" href="https://www.instagram.com/_lilyjfoster_/" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
                             <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.917 3.917 0 0 0-1.417.923A3.927 3.927 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.916 3.916 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.926 3.926 0 0 0-.923-1.417A3.911 3.911 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0h.003zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599.28.28.453.546.598.92.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.47 2.47 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.478 2.478 0 0 1-.92-.598 2.48 2.48 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233 0-2.136.008-2.388.046-3.231.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92.28-.28.546-.453.92-.598.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045v.002zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92zm-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217zm0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-4" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
                             <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"/>
                         </svg>
                     </a>
@@ -139,17 +139,17 @@
                     {% endif %}
                     
                     <a class="hover-rotate mt-2" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-twitter" viewBox="0 0 16 16">
                             <path d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-2" href="https://www.instagram.com/_lilyjfoster_/" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-instagram" viewBox="0 0 16 16">
                             <path d="M8 0C5.829 0 5.556.01 4.703.048 3.85.088 3.269.222 2.76.42a3.917 3.917 0 0 0-1.417.923A3.927 3.927 0 0 0 .42 2.76C.222 3.268.087 3.85.048 4.7.01 5.555 0 5.827 0 8.001c0 2.172.01 2.444.048 3.297.04.852.174 1.433.372 1.942.205.526.478.972.923 1.417.444.445.89.719 1.416.923.51.198 1.09.333 1.942.372C5.555 15.99 5.827 16 8 16s2.444-.01 3.298-.048c.851-.04 1.434-.174 1.943-.372a3.916 3.916 0 0 0 1.416-.923c.445-.445.718-.891.923-1.417.197-.509.332-1.09.372-1.942C15.99 10.445 16 10.173 16 8s-.01-2.445-.048-3.299c-.04-.851-.175-1.433-.372-1.941a3.926 3.926 0 0 0-.923-1.417A3.911 3.911 0 0 0 13.24.42c-.51-.198-1.092-.333-1.943-.372C10.443.01 10.172 0 7.998 0h.003zm-.717 1.442h.718c2.136 0 2.389.007 3.232.046.78.035 1.204.166 1.486.275.373.145.64.319.92.599.28.28.453.546.598.92.11.281.24.705.275 1.485.039.843.047 1.096.047 3.231s-.008 2.389-.047 3.232c-.035.78-.166 1.203-.275 1.485a2.47 2.47 0 0 1-.599.919c-.28.28-.546.453-.92.598-.28.11-.704.24-1.485.276-.843.038-1.096.047-3.232.047s-2.39-.009-3.233-.047c-.78-.036-1.203-.166-1.485-.276a2.478 2.478 0 0 1-.92-.598 2.48 2.48 0 0 1-.6-.92c-.109-.281-.24-.705-.275-1.485-.038-.843-.046-1.096-.046-3.233 0-2.136.008-2.388.046-3.231.036-.78.166-1.204.276-1.486.145-.373.319-.64.599-.92.28-.28.546-.453.92-.598.282-.11.705-.24 1.485-.276.738-.034 1.024-.044 2.515-.045v.002zm4.988 1.328a.96.96 0 1 0 0 1.92.96.96 0 0 0 0-1.92zm-4.27 1.122a4.109 4.109 0 1 0 0 8.217 4.109 4.109 0 0 0 0-8.217zm0 1.441a2.667 2.667 0 1 1 0 5.334 2.667 2.667 0 0 1 0-5.334z"/>
                         </svg>
                     </a>
                     <a class="hover-rotate mt-4" href="https://twitter.com/M__Foster" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.25rem, 1.5rem)" height="clamp(1rem, 2vw + 0.25rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="clamp(1rem,2vw + 0.5rem, 1.5rem)" height="clamp(1rem, 2vw + 0.5rem, 1.5rem)" fill="currentColor" class="bi bi-facebook" viewBox="0 0 16 16">
                             <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951z"/>
                         </svg>
                     </a>
@@ -196,19 +196,29 @@
             }
         </script>
         <script>
-            const sidebarOpen = document.querySelector('.btn-style');
-
-            sidebarOpen.addEventListener('click', () => 
+            function openSidebar()
             {
                 document.body.classList.add('sidebar-open');
-            })
+            }
 
-            const sidebarClose = document.querySelector('.btn-style-close');
-
-            sidebarClose.addEventListener('click', () => 
+            function closeSidebar()
             {
                 document.body.classList.remove('sidebar-open');
-            })
+            }
+
+            const container = document.getElementsByClassName('sidebar-slide-out')[0];
+            const button = document.getElementsByClassName('openBtn')[0];
+
+            document.addEventListener('click', ( event ) =>
+            {
+                if (container !== event.target && !container.contains(event.target)) 
+                {    
+                    if(button !== event.target && !button.contains(event.target))
+                    {
+                        document.body.classList.remove('sidebar-open');
+                    }
+                }
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
Improved the look of the sidebar for mobile users.

The sidebar is opened by clicking the hamburger icon.

Now;

- The top-right and bottom-right corners are rounded.
- The content within the sidebar is centred in the sidebar.
- The Image sizes of the social media links and the size of the text scales based upon the width of the sidebar.
- The content of the webpage is frozen and covered in a light gray which has low opacity.
- Now clicking outside the sidebar also closes it, like clicking on the X icon within the sidebar.

Closes #13 