### PR TITLE
Sidebar now Sticky

### DIFF
--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -79,6 +79,8 @@ a, a:hover{
   font-weight: var(--fw-boldest);
   text-align: left;
   padding-left: clamp(10%, 2vw + 15%, 35%);
+  top: 3rem;
+  position: sticky;
 }
 
 .sidebar-slide-out{


### PR DESCRIPTION
The sidebar sticks to the top with a margin of 3rem.

Obviously only occurs on sites where you can scroll down a bit!

Closes #29 