### PR TITLE
34 custom error input fields

### DIFF
--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -7,6 +7,8 @@
   --clr-neutral-300: #888;
   --clr-neutral-100: #FFF;
 
+  --clr-invalid: rgb(226, 39, 39);
+
   --ff-base: 'Poiret One', cursive;
   --ff-accent: 'Tangerine', cursive;
 
@@ -203,6 +205,7 @@ a, a:hover{
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-width: 17.75rem;
 }
 
 .userinput {
@@ -212,6 +215,36 @@ a, a:hover{
   border-right: none;
   font-weight: var(--fw-boldest);
   outline: none;
+}
+
+.userinput-invalid {
+  border-bottom: solid;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font-weight: var(--fw-boldest);
+  outline: none;
+  border-color: var(--clr-invalid);
+  color: var(--clr-invalid);
+}
+
+.userinput-invalid::placeholder {
+  color: var(--clr-invalid);
+  font-weight: var(--fw-bold);
+  opacity: 1;
+}
+
+.userinput-invalid:hover::placeholder {
+  color: var(--clr-invalid);
+  font-weight: var(--fw-regular);
+  opacity: 1;
+}
+
+.invalid-tips {
+  color: var(--clr-invalid);
+  font-weight: var(--fw-bold);
+  font-size: 1.2rem;
+  max-width: 100%;
 }
 
 #account-info {

--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -207,7 +207,7 @@ a, a:hover{
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  max-width: 17.75rem;
+  max-width: clamp(17.75rem, 4vw + 15rem, 19.1rem);
 }
 
 .userinput {

--- a/ProjectLily/src/static/style.css
+++ b/ProjectLily/src/static/style.css
@@ -157,6 +157,8 @@ a, a:hover{
   display: inline-block;
   position: relative;
   color: var(--clr-neutral-900);
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .hover-underline-animation:after {

--- a/ProjectLily/src/templates/account.html
+++ b/ProjectLily/src/templates/account.html
@@ -15,8 +15,8 @@
                     {{ form.hidden_tag() }}
                     <div>
                         {% if form.name.errors %}
-                            {{ form.name(class="form-control form-control-lg is-invalid") }}
-                            <div class="invalid-feedback">
+                            {{ form.name(class="userinput-invalid", placeholder=form.name.label.text) }}
+                            <div class="invalid-tips">
                                 {% for error in form.name.errors %}
                                     <span>{{ error }}</span>
                                 {% endfor %}
@@ -27,8 +27,8 @@
                     </div>
                     <div>
                         {% if form.email.errors %}
-                            {{ form.email(class="form-control form-control-lg is-invalid") }}
-                            <div class="invalid-feedback">
+                            {{ form.email(class="userinput-invalid", placeholder=form.email.label.text) }}
+                            <div class="invalid-tips">
                                 {% for error in form.email.errors %}
                                     <span>{{ error }}</span>
                                 {% endfor %}
@@ -39,10 +39,10 @@
                     </div>
                     <div>
                         {% if form.phone.errors %}
-                            {{ form.phone(class="form-control form-control-lg is-invalid") }}
-                            <div class="invalid-feedback">
+                            {{ form.phone(class="userinput-invalid", placeholder=form.phone.label.text) }}
+                            <div class="invalid-tips">
                                 {% for error in form.phone.errors %}
-                                    <span>{{ error }}</span>
+                                    <span>Phone number needs to be a number.</span>
                                 {% endfor %}
                             </div>
                         {% else %}

--- a/ProjectLily/src/templates/contact.html
+++ b/ProjectLily/src/templates/contact.html
@@ -10,8 +10,8 @@
             {% if not current_user.is_authenticated %}
             <div>
                 {% if form.name.errors %}
-                    {{ form.name(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ form.name(class="userinput-invalid", placeholder=form.name.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in form.name.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -23,8 +23,8 @@
 
             <div>
                 {% if form.email.errors %}
-                    {{ form.email(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ form.email(class="userinput-invalid", placeholder=form.email.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in form.email.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -36,10 +36,10 @@
 
             <div>
                 {% if form.phone.errors %}
-                    {{ form.phone(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ form.phone(class="userinput-invalid", placeholder=form.phone.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in form.phone.errors %}
-                            <span>{{ error }}</span>
+                            <span>Phone number needs to be a number.</span>
                         {% endfor %}
                     </div>
                 {% else %}
@@ -50,8 +50,8 @@
 
             <div>
                 {% if form.subject.errors %}
-                    {{ form.subject(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ form.subject(class="userinput-invalid", placeholder=form.subject.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in form.subject.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -63,8 +63,8 @@
 
             <div>
                 {% if form.email_content.errors %}
-                    {{ form.email_content(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ form.email_content(class="userinput-invalid", placeholder=form.email_content.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in form.email_content.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}

--- a/ProjectLily/src/templates/request_password_reset.html
+++ b/ProjectLily/src/templates/request_password_reset.html
@@ -13,8 +13,8 @@
 
           <div>
               {% if form.email.errors %}
-                  {{ form.email(class="form-control form-control-lg is-invalid") }}
-                  <div class="invalid-feedback">
+                  {{ form.email(class="userinput-invalid", placeholder=form.email.label.text) }}
+                  <div class="invalid-tips">
                       {% for error in form.email.errors %}
                           <span>{{ error }}</span>
                       {% endfor %}

--- a/ProjectLily/src/templates/reset_password.html
+++ b/ProjectLily/src/templates/reset_password.html
@@ -13,8 +13,8 @@
 
           <div>
               {% if form.password.errors %}
-                  {{ form.password(class="form-control form-control-lg is-invalid") }}
-                  <div class="invalid-feedback">
+                  {{ form.password(class="userinput-invalid", placeholder=form.password.label.text, id="resetPassword") }}
+                  <div class="invalid-tips">
                       {% for error in form.password.errors %}
                           <span>{{ error }}</span>
                       {% endfor %}
@@ -26,8 +26,8 @@
 
           <div>
               {% if form.confirm_password.errors %}
-                  {{ form.confirm_password(class="form-control form-control-lg is-invalid") }}
-                  <div class="invalid-feedback">
+                  {{ form.confirm_password(class="userinput-invalid", placeholder=form.confirm_password.label.text, id="resetPassword2") }}
+                  <div class="invalid-tips">
                       {% for error in form.confirm_password.errors %}
                           <span>{{ error }}</span>
                       {% endfor %}

--- a/ProjectLily/src/templates/signin.html
+++ b/ProjectLily/src/templates/signin.html
@@ -5,8 +5,8 @@
             {{ in_form.hidden_tag() }}
             <div>
                 {% if in_form.email.errors %}
-                    {{ in_form.email(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ in_form.email(class="userinput-invalid", placeholder=in_form.email.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in in_form.email.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -17,8 +17,8 @@
             </div>
             <div>
                 {% if in_form.password.errors %}
-                    {{ in_form.password(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ in_form.password(class="userinput-invalid", placeholder=in_form.password.label.text, id="signInPassword") }}
+                    <div class="invalid-tips">
                         {% for error in in_form.password.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}

--- a/ProjectLily/src/templates/signup.html
+++ b/ProjectLily/src/templates/signup.html
@@ -7,8 +7,8 @@
 
             <div>
                 {% if up_form.firstname.errors %}
-                    {{ up_form.firstname(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.firstname(class="userinput-invalid", placeholder=up_form.firstname.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in up_form.firstname.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -20,8 +20,8 @@
 
             <div>
                 {% if up_form.lastname.errors %}
-                    {{ up_form.lastname(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.lastname(class="userinput-invalid", placeholder=up_form.lastname.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in up_form.lastname.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -33,8 +33,8 @@
 
             <div>
                 {% if up_form.email.errors %}
-                    {{ up_form.email(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.email(class="userinput-invalid", placeholder=up_form.email.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in up_form.email.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -46,10 +46,10 @@
 
             <div>
                 {% if up_form.phone.errors %}
-                    {{ up_form.phone(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.phone(class="userinput-invalid", placeholder=up_form.phone.label.text) }}
+                    <div class="invalid-tips">
                         {% for error in up_form.phone.errors %}
-                            <span>{{ error }}</span>
+                            <span>Phone number needs to be a number.</span>
                         {% endfor %}
                     </div>
                 {% else %}
@@ -59,8 +59,8 @@
 
             <div>
                 {% if up_form.password.errors %}
-                    {{ up_form.password(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.password(class="userinput-invalid", placeholder=up_form.password.label.text, id="signUpPassword") }}
+                    <div class="invalid-tips">
                         {% for error in up_form.password.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}
@@ -72,8 +72,8 @@
 
             <div>
                 {% if up_form.confirm_password.errors %}
-                    {{ up_form.confirm_password(class="form-control form-control-lg is-invalid") }}
-                    <div class="invalid-feedback">
+                    {{ up_form.confirm_password(class="userinput-invalid", placeholder=up_form.confirm_password.label.text, id="signUpPassword2") }}
+                    <div class="invalid-tips">
                         {% for error in up_form.confirm_password.errors %}
                             <span>{{ error }}</span>
                         {% endfor %}


### PR DESCRIPTION
Fixed a few bug issues with links that did not relate to the error input fields.

Added custom error fields when a user tries to submit a form with invalid input(s). The style of the input remains the same unlike before and turns red to alert the user that it is invalid and the error is displayed below the respective input field that was invalid with a description of the error.